### PR TITLE
fix: desactivar navegación instantánea para asegurar estabilidad de scripts externos 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,6 @@ theme:
     - navigation.top
     - navigation.indexes
     - navigation.tabs
-    - navigation.instant
-    - navigation.instant.progress
     - search.highlight
     - search.suggest
     - content.code.copy


### PR DESCRIPTION
  > Se remueve la característica navigation.instant de MkDocs Material en mkdocs.yml.
  
  Razón del cambio:  
  
  > La navegación instantánea (basada en XHR) impedía que los scripts de terceros (como MathJax o
  visualizaciones personalizadas) se reinicializaran correctamente al cambiar de página, provocando que las
  fórmulas o gráficos desaparecieran tras navegar internamente. Desactivarlo asegura que cada página cargue su
  estado completo de forma robusta.
