### PR TITLE
feat: agregar soporte para renderizado de fórmulas LaTeX con MathJax

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -12,5 +12,10 @@ window.MathJax = {
 };
 
 document$.subscribe(() => {
-  MathJax.typesetPromise()
+  if (window.MathJax && MathJax.startup) {
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+  }
 })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,10 @@ extra:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
 nav:
   - Inicio: index.md
   - Cronograma: cronograma.md
@@ -86,3 +90,5 @@ markdown_extensions:
   - md_in_html
   - toc:
       permalink: true
+  - pymdownx.arithmatex:
+      generic: true


### PR DESCRIPTION
  ### Descripción:
  Se integra MathJax 3 para permitir el renderizado correcto de ecuaciones matemáticas en todo el sitio de
  documentación.
  
  ### Cambios realizados:
   - Configuración de la extensión pymdownx.arithmatex en mkdocs.yml para procesar sintaxis de dólar ($...$ y
  $$...$$).
  - Creación de docs/javascripts/mathjax.js con la configuración de renderizado y suscripción al evento de
  carga.
  - Inclusión de los scripts necesarios desde CDN (MathJax 3) en la configuración de MkDocs.
